### PR TITLE
fix npm install warn

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "mocha": "*"
   },
   "bugs": {
-    "url": ""
+    "url": "https://github.com/targetkiller/gulp-imageisux/issues"
   },
   "homepage": "https://github.com/targetkiller/gulp-imageisux",
   "_id": "gulp-imageisux@1.0.1",


### PR DESCRIPTION
解决npm install 警告问题
npm WARN package.json gulp-imageisux@1.0.2 Normalized value of bugs field is an empty object. Deleted.

顺便问一个问题，就不再issues提了
智图优化图片的模块现在还不开源吗？现在需要依赖于 needle.post('http://image.isux.us/index.php/preview/upload_file',) 来处理
